### PR TITLE
[Park] eslint 환경설정 및 back scripts 수정

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon --exec babel-node init.js --delay 1",
+    "start": "babel-node init.js --delay 1",
+    "start:watch": "nodemon --exec npm start",
     "lint": "eslint src --fix"
   },
   "keywords": [],

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -32,5 +32,7 @@ module.exports = {
     "no-bitwise": "off",
     "consistent-return": "off",
     "import/prefer-default-export": "off",
+    "func-names": "off",
+    "no-underscore-dangle": ["error", { allow: ["_id"] }],
   },
 };


### PR DESCRIPTION
- back/package.json
윈도우에서 `nodemon --exec` 사용시 exec 에서 devDependency 에 있는 babel-node 를 불러오지 못하여
다른 환경에서도 동일한 scripts 를 사용할 수 있도록 scripts 를 변경하였습니다.
 
- front/.eslintrc.js
peact 는 모듈패턴을 사용하는데 익명함수에 대한 lint 가 warning 이 나와서 익명함수에 대한 lint 가 필요한지 협의한 이후 off 하였습니다.
몽고DB 에서 사용되는 id 의 기본 키값이 `_id` 인데, eslint 에서 `no-underscore-dangle` 을 error 로 사용하여서, `_id` 만 예외로 처리할 수 있도록 변경하였습니다. 
