### PR TITLE
[Park] webpack devtool 설정 반대로 되어있던 것 수정 

### DIFF
--- a/front/src/components/Content/Card/Card.js
+++ b/front/src/components/Content/Card/Card.js
@@ -79,7 +79,7 @@ const Card = ({ todo, handleRenderFlag }) => {
     child: [todo.author],
   });
 
-  return peact.createElement({
+  const $card = peact.createElement({
     tag: "div",
     className: styles.card,
     attrs: {
@@ -87,6 +87,8 @@ const Card = ({ todo, handleRenderFlag }) => {
     },
     child: [$cardHeaderArea, $cardContent, $cardAuthor],
   });
+
+  return $card;
 };
 
 export default Card;

--- a/front/src/components/Content/CardWritable/CardWritable.js
+++ b/front/src/components/Content/CardWritable/CardWritable.js
@@ -2,7 +2,7 @@ import peact from "../../../core/peact";
 import Button from "../../../tagComponents/Button";
 import styles from "./cardWritable.module.css";
 
-const CardWritable = ({ handleNewCardVisibility }) => {
+const CardWritable = ({ handleNewCardVisibility, ref }) => {
   const $inputDesc = peact.createElement({
     tag: "input",
     className: styles.cardDescInput,
@@ -54,6 +54,7 @@ const CardWritable = ({ handleNewCardVisibility }) => {
     tag: "div",
     className: [styles.cardWritable],
     child: [$cardWritableHeader, $inputDesc, $buttonArea],
+    ref,
   });
 };
 

--- a/front/src/components/Content/Columns/Columns.js
+++ b/front/src/components/Content/Columns/Columns.js
@@ -26,7 +26,6 @@ const Columns = ({ columns, todos, handleRenderFlag }) => {
   const createColumnElement = (column) => {
     const newCardRef = peact.useRef();
     const handleNewCardVisibility = () => {
-      console.log(newCardRef.current);
       newCardRef.current.classList.toggle(styles.visible);
     };
     const $newCard = CardWritable({ handleNewCardVisibility, ref: newCardRef });

--- a/front/src/components/Content/Columns/Columns.js
+++ b/front/src/components/Content/Columns/Columns.js
@@ -26,6 +26,7 @@ const Columns = ({ columns, todos, handleRenderFlag }) => {
   const createColumnElement = (column) => {
     const newCardRef = peact.useRef();
     const handleNewCardVisibility = () => {
+      console.log(newCardRef.current);
       newCardRef.current.classList.toggle(styles.visible);
     };
     const $newCard = CardWritable({ handleNewCardVisibility, ref: newCardRef });

--- a/front/webpack.config.js
+++ b/front/webpack.config.js
@@ -52,6 +52,6 @@ module.exports = (env) => {
         },
       ],
     },
-    ...(isDeploy ? { devtool: "source-map" } : {}),
+    ...(isDeploy ? {} : { devtool: "source-map" }),
   };
 };


### PR DESCRIPTION
source-map 사용이 안되어서 보니 설정이 반대로 되어있더라구요..
다시 고쳐놓았습니다.

Columns 로직에서 ref 를 사용하는 곳도 CardWritable 에서 사용되어야 하기에 추가해놓았습니다.